### PR TITLE
Fix swapped division and multiplication in calculating angular speed

### DIFF
--- a/panther_driver/src/ClassicKinematics.py
+++ b/panther_driver/src/ClassicKinematics.py
@@ -36,12 +36,12 @@ class PantherClassic(PantherKinematics):
         angular_velocity_z_ = (-wheel_FL_ang_vel + wheel_FR_ang_vel - wheel_RL_ang_vel + wheel_RR_ang_vel) * (
             self.wheel_radius/(4 * (self.robot_width / 2 + self.robot_length / 2)))
 
-        delta_heading = angular_velocity_z_ / dt_  # [radians]
+        delta_heading = angular_velocity_z_ * dt_  # [radians]
         self.robot_th_pos = self.robot_th_pos + delta_heading
         delta_x = (linear_velocity_x_ * math.cos(self.robot_th_pos) -
-                   linear_velocity_y_ * math.sin(self.robot_th_pos)) / dt_  # [m]
+                   linear_velocity_y_ * math.sin(self.robot_th_pos)) * dt_  # [m]
         delta_y = (linear_velocity_x_ * math.sin(self.robot_th_pos) +
-                   linear_velocity_y_ * math.cos(self.robot_th_pos)) / dt_  # [m]
+                   linear_velocity_y_ * math.cos(self.robot_th_pos)) * dt_  # [m]
         self.robot_x_pos = self.robot_x_pos + delta_x
         self.robot_y_pos = self.robot_y_pos + delta_y
         return self.robot_x_pos, self.robot_y_pos, self.robot_th_pos

--- a/panther_driver/src/MecanumKinematics.py
+++ b/panther_driver/src/MecanumKinematics.py
@@ -37,12 +37,12 @@ class PantherMecanum(PantherKinematics):
         angular_velocity_z_ = (-wheel_FL_ang_vel + wheel_FR_ang_vel - wheel_RL_ang_vel + wheel_RR_ang_vel) * (
             self.wheel_radius/(4 * (self.robot_width / 2 + self.robot_length / 2)))
 
-        delta_heading = angular_velocity_z_ / dt_  # [radians]
+        delta_heading = angular_velocity_z_ * dt_  # [radians]
         self.robot_th_pos = self.robot_th_pos + delta_heading
         delta_x = (linear_velocity_x_ * math.cos(self.robot_th_pos) -
-                   linear_velocity_y_ * math.sin(self.robot_th_pos)) / dt_  # [m]
+                   linear_velocity_y_ * math.sin(self.robot_th_pos)) * dt_  # [m]
         delta_y = (linear_velocity_x_ * math.sin(self.robot_th_pos) +
-                   linear_velocity_y_ * math.cos(self.robot_th_pos)) / dt_  # [m]
+                   linear_velocity_y_ * math.cos(self.robot_th_pos)) * dt_  # [m]
         self.robot_x_pos = self.robot_x_pos + delta_x
         self.robot_y_pos = self.robot_y_pos + delta_y
         return self.robot_x_pos, self.robot_y_pos, self.robot_th_pos

--- a/panther_driver/src/MixedKinematics.py
+++ b/panther_driver/src/MixedKinematics.py
@@ -35,12 +35,12 @@ class PantherMix(PantherKinematics):
         angular_velocity_z_ = (-wheel_FL_ang_vel + wheel_FR_ang_vel - wheel_RL_ang_vel + wheel_RR_ang_vel) * (
             self.wheel_radius/(4 * (self.robot_width / 2 + self.robot_length / 2)))
 
-        delta_heading = angular_velocity_z_ / dt_  # [radians]
+        delta_heading = angular_velocity_z_ * dt_  # [radians]
         self.robot_th_pos = self.robot_th_pos + delta_heading
         delta_x = ((linear_velocity_x_ * math.cos(self.robot_th_pos) -
-                    linear_velocity_y_ * math.sin(self.robot_th_pos)) / dt_)  # [m]
+                    linear_velocity_y_ * math.sin(self.robot_th_pos)) * dt_)  # [m]
         delta_y = ((linear_velocity_x_ * math.sin(self.robot_th_pos) +
-                    linear_velocity_y_ * math.cos(self.robot_th_pos)) / dt_)  # [m]
+                    linear_velocity_y_ * math.cos(self.robot_th_pos)) * dt_)  # [m]
         self.robot_x_pos = self.robot_x_pos + delta_x
         self.robot_y_pos = self.robot_y_pos + delta_y
         return self.robot_x_pos, self.robot_y_pos, self.robot_th_pos

--- a/panther_driver/src/driver_node.py
+++ b/panther_driver/src/driver_node.py
@@ -342,10 +342,10 @@ def driverNode():
             wheel_RR_ang_pos = 2 * math.pi * position_RR / RK.encoder_resolution
 
             wheel_FL_ang_vel = (wheel_FL_ang_pos -
-                                wheel_FL_ang_pos_last) * dt_  # rad/s
-            wheel_FR_ang_vel = (wheel_FR_ang_pos - wheel_FR_ang_pos_last) * dt_
-            wheel_RL_ang_vel = (wheel_RL_ang_pos - wheel_RL_ang_pos_last) * dt_
-            wheel_RR_ang_vel = (wheel_RR_ang_pos - wheel_RR_ang_pos_last) * dt_
+                                wheel_FL_ang_pos_last) / dt_  # rad/s
+            wheel_FR_ang_vel = (wheel_FR_ang_pos - wheel_FR_ang_pos_last) / dt_
+            wheel_RL_ang_vel = (wheel_RL_ang_pos - wheel_RL_ang_pos_last) / dt_
+            wheel_RR_ang_vel = (wheel_RR_ang_pos - wheel_RR_ang_pos_last) / dt_
 
             wheel_FL_ang_pos_last = wheel_FL_ang_pos
             wheel_FR_ang_pos_last = wheel_FR_ang_pos


### PR DESCRIPTION
I think I found the reason for which the angular speeds seemed to be so small. While calculating the angular speeds, instead of dividing `deltaAngularPosition` by `dt`, you were multiplying them.

X-Y positions and heading were unaffected by it, because the operation was always reversed in `inverseKinematics()` so nobody noticed it so far.